### PR TITLE
* Add an undocumented instruction of x86.

### DIFF
--- a/specifications/x86/x86-rreil-translator-m-z.ml
+++ b/specifications/x86/x86-rreil-translator-m-z.ml
@@ -2289,6 +2289,15 @@ val sem-sahf x = do
   emit-virt-flags
 end
 
+val sem-salc x = do
+  al <- return (semantic-register-of AL);
+  cf <- fCF;
+  _if (/eq 1 (var cf) (imm 0)) _then
+      mov al.size al (imm 0)
+      _else
+      mov al.size al (imm 0xff)
+end
+
 val sem-sal-shl x = do
   sz <- sizeof1 x.opnd1;
   dst <- lval sz x.opnd1;

--- a/specifications/x86/x86-rreil-translator.ml
+++ b/specifications/x86/x86-rreil-translator.ml
@@ -1522,6 +1522,7 @@ in
    | RSQRTSS x: sem-default-arity2 insn.insn (comb x)
    | SAHF: sem-sahf (comb {})
    | SAL x: sem-sal-shl (comb x)
+   | SALC: sem-salc (comb {})
    | SAR x: sem-shr-sar (comb x) '1'
    | SBB x: sem-sbb (comb x)
    | SCASB: sem-scas 8 (comb {})

--- a/specifications/x86/x86-traverse.ml
+++ b/specifications/x86/x86-traverse.ml
@@ -555,6 +555,7 @@ val traverse f insn = case insn of
  | RSQRTSS a: f "RSQRTSS" (UA2 a)
  | SAHF: f "SAHF" UA0
  | SAL a: f "SAL" (UA2 a)
+ | SALC: f "SALC" UA0
  | SAR a: f "SAR" (UA2 a)
  | SBB a: f "SBB" (UA2 a)
  | SCASB: f "SCASB" UA0

--- a/specifications/x86/x86.ml
+++ b/specifications/x86/x86.ml
@@ -1299,6 +1299,7 @@ type x86-insn =
  | RSQRTSS of arity2
  | SAHF
  | SAL of arity2
+ | SALC 
  | SAR of arity2
  | SBB of arity2
  | SCASB
@@ -5536,6 +5537,10 @@ val /vex/f3/0f/vexv [0x52 /r] = varity3 avx VRSQRTSS xmm128 v/xmm xmm/m32
 ###  - Store AH into Flags
 val / [0x9e] = arity0 none SAHF
 
+### SALC
+### Undocumented Opcode.
+val / [0xd6] = arity0 none SALC               
+                      
 ### SAL/SAR/SHL/SHR
 ### - Shift
 #### SAL/SHL


### PR DESCRIPTION
I added an undocumented instruction of X86, called SALC.
This instruction itself has no significant functionality, but some malware use it just for confusing disassemblers. 
Detailed information is available at, e.g., http://www.rcollins.org/secrets/opcodes/SALC.html.
