### PR TITLE
Small fixes of CMakeLists.txt's for OS X.

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required (VERSION 2.8)
 project (gdsl-libs)
+include (CheckFunctionExists)
+check_function_exists (open_memstream HAVE_MEMSTREAM)
+if (NOT HAVE_MEMSTREAM)
+    add_subdirectory(memstream)
+endif (NOT HAVE_MEMSTREAM)
 
 add_subdirectory(gdsl-multiplex)
 add_subdirectory(cppgdsl)

--- a/libs/gdsl-multiplex/CMakeLists.txt
+++ b/libs/gdsl-multiplex/CMakeLists.txt
@@ -4,7 +4,6 @@ project (multiplex)
 file(GLOB_RECURSE SOURCES
   "src/**.c"
 )
-
 add_library(multiplex SHARED ${SOURCES})
 target_include_directories(multiplex PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
@@ -12,7 +11,9 @@ target_include_directories(multiplex PUBLIC
 )
 set_target_properties(multiplex PROPERTIES C_STANDARD 11)
 target_link_libraries(multiplex dl)
-
+if (NOT HAVE_MEMSTREAM)
+    target_link_libraries(multiplex memstream)
+endif (NOT HAVE_MEMSTREAM)
 list(APPEND EXPORT_LIBRARIES multiplex)
 install(TARGETS multiplex
   # IMPORTANT: Add the library to the "export-set"

--- a/libs/gdutil/CMakeLists.txt
+++ b/libs/gdutil/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required (VERSION 2.8)
 project (gdutil)
+find_path(HAS_GELF_H gelf.h)
+if (NOT HAS_GELF_H)
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+	    pkg_check_modules(LIBELF REQUIRED libelf)
+    endif (PKG_CONFIG_FOUND)
+endif (NOT HAS_GELF_H)
 
 file(GLOB_RECURSE SOURCES
   "src/**.c"
@@ -13,6 +20,10 @@ macro(gdutil fend)
   )
   set_target_properties(gdutil_${fend} PROPERTIES C_STANDARD 11)
   target_link_libraries(gdutil_${fend} multiplex)
+  if (LIBELF_FOUND) 
+    target_include_directories (gdutil_${fend} PUBLIC ${LIBELF_INCLUDE_DIRS})
+    target_link_libraries (gdutil_${fend} ${LIBELF_LDFLAGS})
+  endif (LIBELF_FOUND)
 
   list(APPEND EXPORT_LIBRARIES gdutil_${fend})
   install(TARGETS gdutil_${fend}

--- a/libs/memstream/CMakeLists.txt
+++ b/libs/memstream/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required (VERSION 2.8)
+project (memstream)
+
+file(GLOB_RECURSE SOURCES
+  "src/**.c"
+)
+
+add_library(memstream SHARED ${SOURCES})
+target_include_directories(memstream PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+  $<INSTALL_INTERFACE:include/>  # <prefix>/include/
+)
+set_target_properties(memstream PROPERTIES C_STANDARD 11)
+
+list(APPEND EXPORT_LIBRARIES memstream)
+install(TARGETS memstream
+  # IMPORTANT: Add the library to the "export-set"
+  EXPORT gdslTargets
+  RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib
+  PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/"
+    COMPONENT dev)
+
+set (EXPORT_LIBRARIES ${EXPORT_LIBRARIES} PARENT_SCOPE)


### PR DESCRIPTION
I made small fixes of CMakeLists.txt for OS X.

- add memstream library if open_memstream function is not available.

- configurations for libelf can be taken from pkg-config.